### PR TITLE
README.rst: Fix "hypertext" reference

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ Jim Webber's most excellent `REST in Practice`_.  Here is a brief recap:
    shows up.  Instead of the URL being formulated by the user of the
    service based on what they want to do and some URL pattern syntax, the
    available actions are represented directly in the document as named
-   links.  See `REST APIs must by hypertext-driven <hypertext>`_ for a
+   links.  See `REST APIs must by hypertext-driven`_ for a
    well-written and relatively short rationale.
 
 That is the part of the story that this library attempts to fill.  It
@@ -140,7 +140,7 @@ Ok... Where?
 .. _Dr. Fielding: http://www.ics.uci.edu/~fielding/pubs/dissertation/top.htm
 .. _Flask: http://flask.pocoo.org
 .. _HATEOAS: http://www.slideshare.net/d0nn9n/jimwebber-rest
-.. _hypertext: http://roy.gbiv.com/untangled/2008/rest-apis-must-be-hypertext-driven
+.. _REST APIs must by hypertext-driven: http://roy.gbiv.com/untangled/2008/rest-apis-must-be-hypertext-driven
 .. _REST in Practice: http://www.amazon.com/gp/product/0596805829?ie=UTF8&tag=jimwebbesblog-20&linkCode=xm2&camp=1789&creativeASIN=0596805829
 .. _Richardson Maturity Model: http://www.crummy.com/writing/speaking/2008-QCon/act3.html
 .. _Tornado: http://tornadoweb.org


### PR DESCRIPTION
I think PyPI didn't like your attempt at a "named hyperlink" (`<hypertext>_`), because:

```
restview --pypi-strict README.rst
```

complained about it with: `"link scheme not allowed: hypertext"`

I think if you merge this and do `python setup.py register`, it will probably fix your description on PyPI and make it look much nicer.

[restview](https://pypi.python.org/pypi/restview) (from @mgedmin) with `--pypi-strict` is the only tool I know of that can detect this error as it duplicates the link scheme whitelist code that PyPI has; this is a part of PyPI and not docutils so most docutils rendering tools won't flag this as an error. Very tricky.

In general, PyPI is very strict about reST. See https://bitbucket.org/pypa/pypi/pull-request/60/fix-bb-214-make-rst-rendering-not-fail-for/diff for a possible solution to the general problem of it being too strict, although I think that PR as-is probably wouldn't fix this problem because this originates from the `ALLOWED_SCHEMES` code. Maybe that could be relaxed so that an invalid scheme causes the URL to be invalidated but not the entire document.

Cc: @mgedmin, @r1chardj0n3s, @dstufft, @ionelmc
